### PR TITLE
ping/pong improvements

### DIFF
--- a/rosboard/html/js/transports/WebSocketV1Transport.js
+++ b/rosboard/html/js/transports/WebSocketV1Transport.js
@@ -42,7 +42,8 @@ class WebSocketV1Transport {
   
         if(wsMsgType === WebSocketV1Transport.MSG_PING) {
           this.send(JSON.stringify([WebSocketV1Transport.MSG_PONG, {
-            [WebSocketV1Transport.PONG_TIME]: Date.now()
+            [WebSocketV1Transport.PONG_SEQ]: data[1][WebSocketV1Transport.PING_SEQ],
+            [WebSocketV1Transport.PONG_TIME]: Date.now(),
           }]));
         }
         else if(wsMsgType === WebSocketV1Transport.MSG_MSG && that.onMsg) that.onMsg(data[1]);
@@ -73,4 +74,6 @@ class WebSocketV1Transport {
   WebSocketV1Transport.MSG_SYSTEM = "y";
   WebSocketV1Transport.MSG_UNSUB = "u";
 
+  WebSocketV1Transport.PING_SEQ= "s";
+  WebSocketV1Transport.PONG_SEQ = "s";
   WebSocketV1Transport.PONG_TIME = "t";

--- a/rosboard/html/js/viewers/Viewer.js
+++ b/rosboard/html/js/viewers/Viewer.js
@@ -90,6 +90,9 @@ class Viewer {
           "color": "#ffffff",
           "padding": "20pt",
         }).appendTo(this.card);
+        this.card.content.css({
+          "display": "none",
+        })
       }
       this.card.error.text(data._error).css({
         "display": "",

--- a/rosboard/rosboard.py
+++ b/rosboard/rosboard.py
@@ -76,6 +76,10 @@ class ROSBoardNode(object):
         self.event_loop = tornado.ioloop.IOLoop()
         self.tornado_application.listen(self.port)
 
+        # allows tornado to log errors to ROS
+        self.logwarn = rospy.logwarn
+        self.logerr = rospy.logerr
+
         # tornado event loop. all the web server and web socket stuff happens here
         threading.Thread(target = self.event_loop.start, daemon = True).start()
 


### PR DESCRIPTION
Assign a seq number to each ping/pong and track it since in some cases the latency can exceed a ping cycle; track that and close out connections that don't respond in >10s. Helpful to avoid a big backlog queue of outgoing messages on server if the client is unable to handle it due to bandwidth or cpu