### PR TITLE
fix layout twitching

### DIFF
--- a/rosboard/html/js/index.js
+++ b/rosboard/html/js/index.js
@@ -46,12 +46,8 @@ $(() => {
     gutter: 10,
     percentPosition: true,
   });
+  $grid.masonry("layout");
 });
-
-setInterval(() => {
-  $grid.masonry("reloadItems");
-  $grid.masonry();
-}, 500);
 
 setInterval(() => {
   if(currentTransport && !currentTransport.isConnected()) {
@@ -211,6 +207,7 @@ function initSubscribe({topicName, topicType}) {
       card.remove();
     }
     $grid.masonry("appended", card);
+    $grid.masonry("layout");
   }
   updateStoredSubscriptions();
 }
@@ -277,6 +274,7 @@ Viewer.onClose = function(viewerInstance) {
   let topicType = viewerInstance.topicType;
   currentTransport.unsubscribe({topicName:topicName});
   $grid.masonry("remove", viewerInstance.card);
+  $grid.masonry("layout");
   delete(subscriptions[topicName].viewer);
   delete(subscriptions[topicName]);
   updateStoredSubscriptions();


### PR DESCRIPTION
This change fixes the minor layout/visualizer twitching.

I've noticed the twitching on all but the first visualizer, Ubuntu 20.04, Firefox.
I'll add screen captures showing before/after soon.