### PR TITLE
Add snap packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ROSboard 
+# ROSboard
 
 ROS node that runs a web server on your robot.
 Run the node, point your web browser at http://your-robot-ip:8888/ and you get nice visualizations.
@@ -46,6 +46,33 @@ For ROS 1, run it with `rosrun rosboard rosboard_node` or put it in your launch 
 
 For ROS 2, run it with `ros2 run rosboard rosboard_node` or put it in your launch file.
 
+## Installing it as a snap
+
+To install `rosboard` as a snap simply run:
+
+```terminal
+snap install rosboard
+```
+
+You can immediately run it with:
+
+```terminal
+rosboard
+```
+
+All ROS topics visualizers are readily available.
+
+### Note
+
+The following is optional and only necessary if you use the related visualizers.
+
+In order to display the core temperatures in the 'SYSTEM: System stats' visualizer,
+you need to connect the snap `hardware-observe` interface as follows:
+
+```terminal
+snap connect rosboard:hardware-observe
+```
+
 ## FAQ
 
 **How do I write a visualizer for a custom type?**
@@ -81,11 +108,11 @@ This project makes use of a number of open-source libraries which the author is 
 - [simplejpeg](https://gitlab.com/jfolz/simplejpeg): Used for encoding and decoding JPEG format.
   Copyright (C) Joachim Folz
   MIT License
- 
+
 - [Masonry](https://masonry.desandro.com/): Used for laying out cards on the page.
   Copyright (C) David DeSandro
   MIT License
- 
+
 - [Leaflet.js](https://github.com/Leaflet/Leaflet): Used for rendering sensor_msgs/NavSatFix messages.
   Copyright (C) Vladimir Agafonkin
   CloudMade, BSD 2-clause license

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,25 @@
   <license>BSD</license>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">rospy</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 2">rcl_interfaces</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rclpy</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">builtin_interfaces</exec_depend>
+
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>rosgraph_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <exec_depend>python3-psutil</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-tornado</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
+
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_python</build_type>

--- a/snap/local/disable_dmesg.patch
+++ b/snap/local/disable_dmesg.patch
@@ -1,0 +1,21 @@
+diff --git rosboard/html/js/index.js rosboard/html/js/index.js
+index c945f3e..177bfb9 100644
+--- rosboard/html/js/index.js
++++ rosboard/html/js/index.js
+@@ -129,11 +129,11 @@ let onTopics = function(topics) {
+   
+   addTopicTreeToNav(topicTree[0], $('#topics-nav-ros'));
+ 
+-  $('<a></a>')
+-  .addClass("mdl-navigation__link")
+-  .click(() => { initSubscribe({topicName: "_dmesg", topicType: "rcl_interfaces/msg/Log"}); })
+-  .text("dmesg")
+-  .appendTo($("#topics-nav-system"));
++  // $('<a></a>')
++  // .addClass("mdl-navigation__link")
++  // .click(() => { initSubscribe({topicName: "_dmesg", topicType: "rcl_interfaces/msg/Log"}); })
++  // .text("dmesg")
++  // .appendTo($("#topics-nav-system"));
+ 
+   $('<a></a>')
+   .addClass("mdl-navigation__link")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,84 @@
+name: rosboard
+version: '1.2.1'
+summary: ROS node that turns your robot into a web server to visualize ROS topics
+description: |
+  ROS node that runs a web server on your robot. Run the node,
+  point your web browser at http://your-robot-ip:8888/ and you get nice visualizations.
+
+  ROS1/ROS2 compatible. This package will work in either ROS version.
+
+  **Mobile friendly**. Designed so you can walk around next to your robot with a phone while viewing ROS topics.
+
+  **Light weight**. Doesn't depending on much. Consumes extremely little resources when it's not actually being used.
+
+  **Easily extensible**. Easily code a visualization for a custom type by only adding only one .js file and referncing it inside the top of index.js.
+
+  You can run it on your desktop too and play a ROS bag.
+
+  Also be sure to check out my terminal visualization tool, `rosshow` at https://github.com/dheera/rosshow.
+
+  To install `rosboard` as a snap simply run:
+
+  `snap install rosboard`
+
+  You can immediately run it with:
+
+  `rosboard`
+
+  All ROS topics visualizers are readily available.
+
+  The following is optional and only necessary if you use the related visualizers.
+
+  In order to display the core temperatures in the 'SYSTEM: System stats' visualizer,
+  you need to connect the snap `hardware-observe` interface as follows:
+
+  `snap connect rosboard:hardware-observe`
+
+grade: stable
+confinement: strict
+base: core20 # Noetic
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
+
+parts:
+
+  # Install some ROS messages that one may want to visualize
+  # and do not explicitely appear in rosboard codebase.
+  ros-messages:
+    plugin: nil
+    stage-packages:
+      - ros-noetic-dynamic-reconfigure
+      - ros-noetic-tf2-msgs
+
+  rosboard:
+    plugin: catkin
+    source: .
+    # Apply a patch to disable the 'dmesg' visualizer since it requires
+    # a 'system-files' plugs which in-turns requires approval to
+    # upload the snap to the store. We can re-enable it by either requesting
+    # 'system-files' approval on the snapcraft forum or working with the
+    # team to see '/dev/kmesg' with read-only permission being added to 'log-observe'.
+    override-pull: |
+      snapcraftctl pull
+      git apply -v --directory=rosboard ./snap/local/disable_dmesg.patch
+    build-packages:
+      - git
+    stage-packages:
+      - procps # for top
+      - ros-noetic-rosbash # for rosrun
+
+apps:
+
+  rosboard:
+    command: opt/ros/noetic/bin/rosrun rosboard rosboard_node
+    plugs:
+      - network # ROS messages
+      - network-bind # ROS messages
+      - hardware-observe # psutil reading temps
+    extensions: [ros1-noetic]
+    environment:
+      "LD_LIBRARY_PATH": "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"
+      "ROS_HOME": "$SNAP_USER_DATA" # remap HOME for rospack


### PR DESCRIPTION
This PR adds [snap](https://snapcraft.io/about) packaging to rosboard.

To give it a shot, first install it:

```bash
snap install rosboard --channel=edge
```

And off you go:

```bash
rosboard
```

You don't even need ROS to be installed on the host to use it since the snap packages all rosboard dependencies.

At the moment [I own the 'rosboard' name on the snap store](https://snapcraft.io/rosboard); I'd be more than happy to transfer it to you.

Please, feel free to ping me with any question you might have.

A few notes:

- The snap currently on the store was packaged based on `Noetic`. Altho I tested it fine against my `Melodic` simulation.
- I've added every dependency that explicitly appears in the codebase - whether they are optional or not - to the `package.xml` file so that e.g. `rosdep` can install them.
- Snap being confined, it cannot access ROS packages on the host machine. Therefore you need to bundle every message that you might want to support. For instance, I've added a couple more typical ROS msgs [here](https://github.com/dheera/rosboard/compare/main...artivis:feature/snap?expand=1#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R50). One could grow that list based on user requests for instance.
- The `dmesg` visualizer is ['disabled'](https://github.com/dheera/rosboard/compare/main...artivis:feature/snap?expand=1#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R59) at the moment

--- 

Marked as draft until https://github.com/snapcore/snapcraft/pull/3570 gets merged.