### PR TITLE
Add launch file with port arg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,8 @@ catkin_install_python(PROGRAMS
   nodes/rosboard_node
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+install(DIRECTORY
+    launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/launch/rosboard.launch
+++ b/launch/rosboard.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<launch>
+    <arg name="port" default="8888"/>
+    <node name="rosboard" pkg="rosboard" type="rosboard_node" output="screen">
+        <param name="port" value="$(arg port)"/>
+    </node>
+</launch>


### PR DESCRIPTION
I added a launch file (ROS1) with an argument to specify the port. It is installed to the shared package dest so one can run:

```bash
roslaunch rosboard rosboard.launch port:=####
```

In my case this is needed to use the `--wait` arg to tell `roslaunch` to wait for `roscore` before starting the node.