### PR TITLE
fixed comma in float convertion

### DIFF
--- a/rosboard/subscribers/processes_subscriber.py
+++ b/rosboard/subscribers/processes_subscriber.py
@@ -43,12 +43,11 @@ class ProcessesSubscriber(object):
 
                     if fields is None:
                         continue
-
                     output.append({
                         "pid": int(line[fields["PID"][0] : fields["PID"][1]]),
                         "user": line[fields["USER"][0] : fields["USER"][1]].strip(),
-                        "cpu": float(line[fields["%CPU"][0] : fields["%CPU"][1]]),
-                        "mem": float(line[fields["%MEM"][0] : fields["%MEM"][1]]),
+                        "cpu": float(line[fields["%CPU"][0] : fields["%CPU"][1]].replace(',','.')),
+                        "mem": float(line[fields["%MEM"][0] : fields["%MEM"][1]].replace(',','.')),
                         "command": line[fields["COMMAND"][0] : ].strip(),
                     })
 


### PR DESCRIPTION
System utilities write a dot as a comma in some locations, which breaks the type conversion when opening the process status window. I added safety replace against such situations, which helped in my case.
![Снимок экрана от 2021-09-23 11-10-47](https://user-images.githubusercontent.com/7687321/134475165-31c10f4b-ac49-4589-95a4-0abda3cd7e0e.png)
