### PR TITLE
Add psutil dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ This project makes use of a number of open-source libraries which the author is 
 - [simplejpeg](https://gitlab.com/jfolz/simplejpeg): Used for encoding and decoding JPEG format.
   Copyright (C) Joachim Folz
   MIT License
+
+- [psutil](https://github.com/giampaolo/psutil) - Used for monitoring system resource utilization.
+  Copyright (C) Giampaolo Rodola
+  BSD 3-clause license
  
 - [Masonry](https://masonry.desandro.com/): Used for laying out cards on the page.
   Copyright (C) David DeSandro

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Also be sure to check out my terminal visualization tool, [ROSshow](https://gith
 ## Prerequisites
 
 ```
-sudo pip3 install tornado psutil
+sudo pip3 install tornado
 sudo pip3 install simplejpeg  # recommended, but ROSboard can fall back to cv2 or PIL instead
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Also be sure to check out my terminal visualization tool, [ROSshow](https://gith
 ## Prerequisites
 
 ```
-sudo pip3 install tornado
+sudo pip3 install tornado psutil
 sudo pip3 install simplejpeg  # recommended, but ROSboard can fall back to cv2 or PIL instead
 ```
 

--- a/rosboard/subscribers/processes_subscriber.py
+++ b/rosboard/subscribers/processes_subscriber.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import psutil
 import re
 import select
 import subprocess

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
         'setuptools',
         'tornado>=4.2.1',
     ],
+    extras_require = {
+        'system_stats': ['psutil'],
+    },
     package_data={
         'rosboard': [
             'html/*',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'setuptools',
         'tornado>=4.2.1',
-        'psutil',
     ],
     package_data={
         'rosboard': [

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'setuptools',
         'tornado>=4.2.1',
+        'psutil',
     ],
     package_data={
         'rosboard': [


### PR DESCRIPTION
Hi, thanks for this fantastic project.

The ./run script fails to start inside a venv with the following error:
```
Traceback (most recent call last):
  File "/home/mostafa/tmp/rosboard/./run", line 3, in <module>
    import rosboard.rosboard
  File "/home/mostafa/tmp/rosboard/rosboard/rosboard.py", line 23, in <module>
    from rosboard.subscribers.processes_subscriber import ProcessesSubscriber
  File "/home/mostafa/tmp/rosboard/rosboard/subscribers/processes_subscriber.py", line 3, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```

It can be fixed by installing psutil. So I've added it as a dependency.