### PR TITLE
List dependencies in package.xml instead of README

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,10 @@
   <license>BSD</license>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+
+  <depend>python3-tornado</depend>
+  <depend>python3-simplejpeg-pip</depend>
+
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_python</build_type>


### PR DESCRIPTION
This lets package-managers work out the dependencies.

Such as:

    git clone https://github.com/dheera/rosboard
    rosdep install --from-path . --ignore-src -y
