### PR TITLE
Fixes UnboundLocalError

### DIFF
--- a/rosboard/compression.py
+++ b/rosboard/compression.py
@@ -148,6 +148,7 @@ def compress_compressed_image(msg, output):
         img_jpeg = encode_jpeg(img)
     except Exception as e:
         output["_error"] = "Error: %s" % str(e)
+        return
     output["_data_jpeg"] = base64.b64encode(img_jpeg).decode()
     output["_data_shape"] = list(original_shape)
             


### PR DESCRIPTION
When there's exception inside the `try` `except` block, the variable `img_jpeg` would not exists, resulting in `UnboundLocalError`

```py
    try:
        img = decode_jpeg(bytearray(msg.data))
        ...
        img_jpeg = encode_jpeg(img)               <===== This one most like would not be created
    except Exception as e:
        output["_error"] = "Error: %s" % str(e)
    output["_data_jpeg"] = base64.b64encode(img_jpeg).decode()          <===== This one fails
    output["_data_shape"] = list(original_shape)
```