### PR TITLE
Fix issue with non-finite point values.

### DIFF
--- a/rosboard/compression.py
+++ b/rosboard/compression.py
@@ -263,12 +263,17 @@ def compress_point_cloud2(msg, output):
         decode_fields = ("x", "y", "z")
     else:
         decode_fields = ("x", "y")
-    
+
     try:
         points = decode_pcl2(msg, field_names = decode_fields, skip_nans = True)
     except AssertionError as e:
         output["_error"] = "PointCloud2 error: %s" % str(e)
     
+    # exclude non-finite points
+    points = points[np.isfinite(points['x']) & np.isfinite(points['y'])]
+    if "z" in field_names:
+        points = points[np.isfinite(points['z'])]
+
     if points.size > 65536:
         output["_warn"] = "Point cloud too large, randomly subsampling to 65536 points."
         idx = np.random.randint(points.size, size=65536)


### PR DESCRIPTION
If point cloud points contain infinite values the following warning appears and no pointcloud appears in the visualiser due to xmin, xmax, ymin etc being np.inf.

This commit filters out said points beforehand.

```
[INFO] [1738667751.444701709] [rosboard_node]: ROSboard listening on :8888
404 GET /favicon.ico (127.0.0.1) 5.44ms
[INFO] [1738667770.411407258] [rosboard_node]: Subscribing to /vehicle/velodyne/point_cloud
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:282: RuntimeWarning: invalid value encountered in subtract
  xpoints_uint16 = (65535 * (xpoints - xmin) / (xmax - xmin)).astype(np.uint16)
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:282: RuntimeWarning: invalid value encountered in divide
  xpoints_uint16 = (65535 * (xpoints - xmin) / (xmax - xmin)).astype(np.uint16)
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:289: RuntimeWarning: invalid value encountered in subtract
  ypoints_uint16 = (65535 * (ypoints - ymin) / (ymax - ymin)).astype(np.uint16)
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:289: RuntimeWarning: invalid value encountered in divide
  ypoints_uint16 = (65535 * (ypoints - ymin) / (ymax - ymin)).astype(np.uint16)
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:297: RuntimeWarning: invalid value encountered in subtract
  zpoints_uint16 = (65535 * (zpoints - zmin) / (zmax - zmin)).astype(np.uint16)
/home/david/ros_demo/install/rosboard/lib/python3.10/site-packages/rosboard/compression.py:297: RuntimeWarning: invalid value encountered in divide
  zpoints_uint16 = (65535 * (zpoints - zmin) / (zmax - zmin)).astype(np.uint16)
[INFO] [1738667784.856407582] [rosboard_node]: Subscribing to /vehicle/camera/image_color
```