### PR TITLE
Add the ability to publish messages.

### DIFF
--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -187,6 +187,22 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
             except KeyError:
                 print("KeyError trying to remove sub")
 
+        # client wants to publish to topic
+        elif argv[0] == ROSBoardSocketHandler.MSG_PUB:
+            if len(argv) != 2 or type(argv[1]) is not dict:
+                print("error: pub: bad: %s" % message)
+                return
+
+            topic_name = argv[1].get("topicName")
+            topic_type = argv[1].get("topicType")
+            msg_data = argv[1].get("msg")
+
+            if topic_name is None or topic_type is None or msg_data is None:
+                print("error: pub: missing topicName, topicType, or msg")
+                return
+
+            self.node.publish_message(topic_name, topic_type, msg_data)
+
 ROSBoardSocketHandler.MSG_PING = "p";
 ROSBoardSocketHandler.MSG_PONG = "q";
 ROSBoardSocketHandler.MSG_MSG = "m";
@@ -194,6 +210,7 @@ ROSBoardSocketHandler.MSG_TOPICS = "t";
 ROSBoardSocketHandler.MSG_SUB = "s";
 ROSBoardSocketHandler.MSG_SYSTEM = "y";
 ROSBoardSocketHandler.MSG_UNSUB = "u";
+ROSBoardSocketHandler.MSG_PUB = "pub";
 
 ROSBoardSocketHandler.PING_SEQ = "s";
 ROSBoardSocketHandler.PONG_SEQ = "s";

--- a/rosboard/html/css/index.css
+++ b/rosboard/html/css/index.css
@@ -439,3 +439,134 @@ input, textarea, *[contenteditable=true] {
     transform: rotate(360deg);
   }
 }
+
+/* Publish Dialog Styles */
+#publish-dialog {
+  min-width: 400px;
+  max-width: 600px;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  padding: 0;
+  background-color: #303030;
+  color: #c0c0c0;
+}
+
+#publish-dialog .mdl-dialog__title {
+  background-color: #404040;
+  color: #f0f0f0;
+  margin: 0;
+  padding: 20px 24px;
+  border-radius: 8px 8px 0 0;
+}
+
+#publish-dialog .mdl-dialog__content {
+  background-color: #303030;
+  color: #c0c0c0;
+  padding: 20px 24px;
+}
+
+#publish-dialog .mdl-dialog__actions {
+  background-color: #404040;
+  padding: 12px 24px 20px 24px;
+  border-radius: 0 0 8px 8px;
+}
+
+#publish-dialog .mdl-button {
+  color: #f0f0f0;
+}
+
+#publish-dialog .mdl-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#publish-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+/* Fallback for browsers without ::backdrop support */
+#publish-dialog:not([open]) {
+  display: none;
+}
+
+#publish-dialog[open] {
+  display: block;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+  background-color: #303030;
+}
+
+/* Manual backdrop for older browsers */
+#publish-dialog[open]:before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: -1;
+}
+
+#publish-dialog .mdl-textfield {
+  width: 100%;
+}
+
+#publish-dialog .mdl-textfield__input {
+  color: #f0f0f0;
+  border-bottom-color: #666666;
+}
+
+#publish-dialog .mdl-textfield__input:focus {
+  border-bottom-color: #1976d2;
+}
+
+#publish-dialog .mdl-textfield__label {
+  color: #a0a0a0;
+}
+
+#publish-dialog .mdl-textfield--floating-label.is-focused .mdl-textfield__label {
+  color: #1976d2;
+}
+
+#publish-dialog .mdl-checkbox__label {
+  color: #c0c0c0;
+}
+
+#publish-dialog textarea {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  background-color: #404040;
+  color: #f0f0f0;
+  border: 1px solid #666666;
+  border-radius: 4px;
+  padding: 8px;
+}
+
+#publish-dialog a {
+  color: #64b5f6;
+}
+
+#publish-link {
+  cursor: pointer;
+}
+
+.publish-status {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.publish-status.success {
+  background-color: #2e7d32;
+  color: #c8e6c9;
+}
+
+.publish-status.error {
+  background-color: #c62828;
+  color: #ffcdd2;
+}

--- a/rosboard/html/index.html
+++ b/rosboard/html/index.html
@@ -17,8 +17,38 @@
         <script text="text/javascript" src="js/import-helper.js"></script>
         <script type="text/javascript" src="js/material.min.js" defer></script>
         <script type="text/javascript" src="js/leaflet.js"></script>        
-	      <script type="text/javascript" src="js/gl-matrix.js"></script>
-	      <script type="text/javascript" src="js/litegl.min.js"></script>
+        <script type="text/javascript" src="js/gl-matrix.js"></script>
+        <script type="text/javascript" src="js/litegl.min.js"></script>
+        <script>
+          // Simple dialog polyfill for older browsers
+          (function() {
+            if (typeof HTMLDialogElement === 'undefined' || !HTMLDialogElement.prototype.showModal) {
+              // Create a minimal polyfill
+              if (typeof HTMLDialogElement === 'undefined') {
+                window.HTMLDialogElement = function() {};
+                window.HTMLDialogElement.prototype = {};
+              }
+              HTMLDialogElement.prototype.showModal = function() {
+                this.style.display = 'block';
+                this.open = true;
+                // Add backdrop manually for older browsers
+                if (!this.backdrop) {
+                  this.backdrop = document.createElement('div');
+                  this.backdrop.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);z-index:999;';
+                  document.body.appendChild(this.backdrop);
+                }
+              };
+              HTMLDialogElement.prototype.close = function() {
+                this.style.display = 'none';
+                this.open = false;
+                if (this.backdrop) {
+                  document.body.removeChild(this.backdrop);
+                  this.backdrop = null;
+                }
+              };
+            }
+          })();
+        </script>
         <script type="text/javascript" src="js/index.js" defer></script>
 
         <title>ROSboard</title>
@@ -35,6 +65,12 @@
           </header>
           <div class="mdl-layout__drawer">
             <nav id="topics-nav" class="mdl-navigation">
+                <div id="topics-nav-publish-title" class="topics-nav-title">Publisher</div>
+                <div id="topics-nav-publish">
+                    <a class="mdl-navigation__link" id="publish-link">
+                        <i class="material-icons" style="vertical-align: middle;">publish</i> Publish
+                    </a>
+                </div>
                 <div id="topics-nav-system-title" class="topics-nav-title">System</div>
                 <div id="topics-nav-system"></div>
                 <div id="topics-nav-ros-title" class="topics-nav-title">ROS topics</div>
@@ -54,6 +90,49 @@
     <div class="mdl-snackbar__text"></div>
     <button class="mdl-snackbar__action" type="button"></button>
   </div>
+
+  <!-- Publish Modal Dialog -->
+  <dialog class="mdl-dialog" id="publish-dialog">
+    <h4 class="mdl-dialog__title">Publish ROS Message</h4>
+    <div class="mdl-dialog__content">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="text" id="publish-topic-name" />
+        <label class="mdl-textfield__label" for="publish-topic-name">Topic Name (e.g., /chatter)</label>
+      </div>
+      
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="text" id="publish-topic-type" />
+        <label class="mdl-textfield__label" for="publish-topic-type">Message Type (e.g., std_msgs/String)</label>
+      </div>
+      
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <textarea class="mdl-textfield__input" type="text" rows="6" id="publish-msg-data"></textarea>
+        <label class="mdl-textfield__label" for="publish-msg-data">Message Data (JSON format)</label>
+      </div>
+
+      <div style="margin-top: 15px;">
+        <label class="mdl-checkbox mdl-js-checkbox mdl-checkbox--ripple-effect" for="publish-continuous">
+          <input type="checkbox" id="publish-continuous" class="mdl-checkbox__input" />
+          <span class="mdl-checkbox__label">Continuous Publishing</span>
+        </label>
+      </div>
+
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" id="publish-rate-container" style="display: none;">
+        <input class="mdl-textfield__input" type="number" id="publish-rate" value="1" min="0.1" max="100" step="0.1" />
+        <label class="mdl-textfield__label" for="publish-rate">Rate (Hz)</label>
+      </div>
+
+      <div style="margin-top: 10px;">
+        <a href="#" id="load-template-link" style="font-size: 12px; color: #1976d2;">Load message template for type</a>
+      </div>
+    </div>
+    <div class="mdl-dialog__actions">
+      <button type="button" class="mdl-button" id="publish-once-btn">Publish Once</button>
+      <button type="button" class="mdl-button" id="publish-start-btn" style="display: none;">Start Publishing</button>
+      <button type="button" class="mdl-button" id="publish-stop-btn" style="display: none;">Stop Publishing</button>
+      <button type="button" class="mdl-button close" id="publish-cancel-btn">Cancel</button>
+    </div>
+  </dialog>
 
     </body>
 </html>

--- a/rosboard/html/js/transports/WebSocketV1Transport.js
+++ b/rosboard/html/js/transports/WebSocketV1Transport.js
@@ -1,5 +1,5 @@
 class WebSocketV1Transport {
-    constructor({path, onOpen, onClose, onRosMsg, onTopics, onSystem}) {
+    constructor({path, onOpen, onClose, onMsg, onTopics, onSystem}) {
       this.path = path;
       this.onOpen = onOpen ? onOpen.bind(this) : null;
       this.onClose = onClose ? onClose.bind(this) : null;
@@ -64,6 +64,10 @@ class WebSocketV1Transport {
     unsubscribe({topicName}) {
       this.ws.send(JSON.stringify([WebSocketV1Transport.MSG_UNSUB, {topicName: topicName}]));
     }
+
+    publish({topicName, topicType, msg}) {
+      this.ws.send(JSON.stringify([WebSocketV1Transport.MSG_PUB, {topicName: topicName, topicType: topicType, msg: msg}]));
+    }
   }
   
   WebSocketV1Transport.MSG_PING = "p";
@@ -73,6 +77,7 @@ class WebSocketV1Transport {
   WebSocketV1Transport.MSG_SUB = "s";
   WebSocketV1Transport.MSG_SYSTEM = "y";
   WebSocketV1Transport.MSG_UNSUB = "u";
+  WebSocketV1Transport.MSG_PUB = "pub";
 
   WebSocketV1Transport.PING_SEQ= "s";
   WebSocketV1Transport.PONG_SEQ = "s";

--- a/rosboard/html/js/viewers/meta/Viewer.js
+++ b/rosboard/html/js/viewers/meta/Viewer.js
@@ -74,6 +74,20 @@ class Viewer {
         that.card.pauseButton.find('i').text(that.isPaused ? 'play_arrow' : 'pause');
       });
 
+    // card publish button (opens centralized dialog)
+    card.publishToggleButton = $('<button></button>')
+      .addClass('mdl-button')
+      .addClass('mdl-js-button')
+      .addClass('mdl-button--icon')
+      .addClass('mdl-button--colored')
+      .append($('<i></i>').addClass('material-icons').text('publish'))
+      .appendTo(card.buttons);
+
+    // Open centralized publish dialog with pre-populated data
+    card.publishToggleButton.click(function(e) {
+      that.openPublishDialog();
+    });
+
     // card close button
     card.closeButton = $('<button></button>')
       .addClass('mdl-button')
@@ -105,6 +119,42 @@ class Viewer {
       componentHandler.upgradeAllRegistered();
     }
   }
+
+  /**
+    * Opens the centralized publish dialog with pre-populated data
+  **/
+  openPublishDialog() {
+    const dialog = document.getElementById('publish-dialog');
+    if (!dialog) return;
+
+    // Pre-populate the dialog with this topic's information
+    document.getElementById('publish-topic-name').value = this.topicName;
+    document.getElementById('publish-topic-type').value = this.topicType;
+    
+    // Update Material Design textfield state
+    const topicNameField = document.getElementById('publish-topic-name').parentElement;
+    const topicTypeField = document.getElementById('publish-topic-type').parentElement;
+    if (topicNameField) topicNameField.classList.add('is-dirty');
+    if (topicTypeField) topicTypeField.classList.add('is-dirty');
+
+    // Clear previous message data and status
+    document.getElementById('publish-msg-data').value = '';
+    const msgDataField = document.getElementById('publish-msg-data').parentElement;
+    if (msgDataField) msgDataField.classList.remove('is-dirty');
+    
+    // Reset to single publish mode
+    const continuousCheckbox = document.getElementById('publish-continuous');
+    if (continuousCheckbox) {
+      continuousCheckbox.checked = false;
+      document.getElementById('publish-rate-container').style.display = 'none';
+      document.getElementById('publish-once-btn').style.display = 'inline-block';
+      document.getElementById('publish-start-btn').style.display = 'none';
+      document.getElementById('publish-stop-btn').style.display = 'none';
+    }
+
+    dialog.showModal();
+  }
+
   destroy() {
     this.card.empty();
   }


### PR DESCRIPTION
## Summary
This PR adds comprehensive ROS message publishing capabilities to rosboard, similar to the `ros2 pub` CLI command, with a modern web interface.

## Features Added
- **Centralized Publishing Dialog**: Modal dialog for publishing ROS messages with topic name, type, and JSON message data
- **Publisher Integration**: Publish button on each viewer card that pre-populates the dialog with topic information  
- **Continuous Publishing**: Option to publish messages at specified frequencies (Hz) with start/stop controls
- **Message Templates**: Built-in templates for common message types (std_msgs, geometry_msgs, sensor_msgs, nav_msgs)
- **Dark Theme Integration**: Publishing interface matches rosboard's existing dark theme
- **Input Validation**: JSON validation with helpful error messages
- **Auto-close Behavior**: Dialog management with proper state handling

## Backend Changes
- Enhanced `publish_message()` method in `ROSBoardNode` class
- WebSocket message handling for publishing via `MSG_PUB` messages
- ROS1/ROS2 compatible publishing with proper message class resolution

## Frontend Changes  
- New publishing modal dialog with Material Design components
- JavaScript publishing interface with rate control and validation
- CSS styling for dark theme consistency
- Publisher buttons integrated into viewer cards
- Left navigation publisher entry point

## Usage
1. **From Navigation**: Click "Publish" in the left sidebar for blank publishing dialog
2. **From Viewers**: Click publish button on any viewer card for pre-populated dialog  
3. **Single Publishing**: Enter topic details and message, click "Publish Once"
4. **Continuous Publishing**: Check continuous mode, set rate, and use Start/Stop controls

## Testing
Tested with both single and continuous publishing modes across various message types.