### PR TITLE
add backup ways to read dmesg

### DIFF
--- a/rosboard/subscribers/dmesg_subscriber.py
+++ b/rosboard/subscribers/dmesg_subscriber.py
@@ -24,7 +24,23 @@ class DMesgSubscriber(object):
 
     def start(self):
         try:
-            self.process = subprocess.Popen(['dmesg', '--follow'], stdout = subprocess.PIPE)
+            # Use 'dmesg --human --read-clear' once to dump existing log, then follow via journalctl
+            # This avoids the "Operation not permitted" error in containers / restricted environments
+            # where dmesg --follow requires CAP_SYSLOG.
+            once_proc = subprocess.Popen(['dmesg', '--human', '--read-clear'],
+                                         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            once_stdout, _ = once_proc.communicate()
+            if once_stdout:
+                self.callback(once_stdout.decode('utf-8').strip())
+
+            try:
+                self.process = subprocess.Popen(['journalctl', '-k', '--follow', '-o', 'cat'],
+                                                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            except FileNotFoundError:
+                # journalctl not available either – give up silently
+                self.process = None
+                return
+
             p = select.poll()
             p.register(self.process.stdout, select.POLLIN)
     


### PR DESCRIPTION
改动说明：                                                                                       
                                                                                                      
     原代码直接用 dmesg --follow 读取内核日志，在没有 CAP_SYSLOG 权限的环境（如 Docker 容器、非       
     root 用户）下会报 Operation not permitted。                                                      
                                                                                                      
     修复策略：                                                                                       
                                                                                                      
     1. 先用 dmesg --human --read-clear 一次性尝试读取已有日志（--read-clear                          
     在权限不足时静默失败，不会报错），如果能读到就回调输出                                           
     2. 再切到 journalctl -k --follow -o cat 做持续跟踪——journalctl 通常通过 systemd-journal          
     组权限即可访问，不需要 CAP_SYSLOG                                                                
     3. 如果 journalctl 也不可用（FileNotFoundError），直接静默退出，不报错 