### PR TITLE
Topics Collapsing on left panel

### DIFF
--- a/rosboard/html/js/index.js
+++ b/rosboard/html/js/index.js
@@ -245,12 +245,11 @@ function initDefaultTransport() {
 }
 
 function simplifyTree(tree) {
-  if(tree.children.length == 0) return;
-  if(tree.children.length == 1){
+  tree.children.forEach(child => simplifyTree(child)); 
+  if(tree.children.length === 1){
     tree.name += '/' + tree.children[0].name;	
     tree.children = tree.children[0].children;
   }
-  tree.children.forEach(child => simplifyTree(child)); 
 }
 
 function treeifyPaths(paths) {
@@ -268,8 +267,9 @@ function treeifyPaths(paths) {
       return r[name];
     }, level)
   });
-
-  simplifyTree(result[0]);
+  if(result.length) {
+    simplifyTree(result[0]);
+  }
   return result;
 }
 

--- a/rosboard/html/js/index.js
+++ b/rosboard/html/js/index.js
@@ -246,6 +246,7 @@ function initDefaultTransport() {
 
 function simplifyTree(tree) {
   tree.children.forEach(child => simplifyTree(child)); 
+  if (tree.name === "") return;
   if(tree.children.length === 1){
     if(!tree.children[0].children.length) {
 	return;

--- a/rosboard/html/js/index.js
+++ b/rosboard/html/js/index.js
@@ -244,6 +244,15 @@ function initDefaultTransport() {
   currentTransport.connect();
 }
 
+function simplifyTree(tree) {
+  if(tree.children.length == 0) return;
+  if(tree.children.length == 1){
+    tree.name += '/' + tree.children[0].name;	
+    tree.children = tree.children[0].children;
+  }
+  tree.children.forEach(child => simplifyTree(child)); 
+}
+
 function treeifyPaths(paths) {
   // turn a bunch of ros topics into a tree
   let result = [];
@@ -259,6 +268,8 @@ function treeifyPaths(paths) {
       return r[name];
     }, level)
   });
+
+  simplifyTree(result[0]);
   return result;
 }
 

--- a/rosboard/html/js/index.js
+++ b/rosboard/html/js/index.js
@@ -247,6 +247,9 @@ function initDefaultTransport() {
 function simplifyTree(tree) {
   tree.children.forEach(child => simplifyTree(child)); 
   if(tree.children.length === 1){
+    if(!tree.children[0].children.length) {
+	return;
+    }
     tree.name += '/' + tree.children[0].name;	
     tree.children = tree.children[0].children;
   }


### PR DESCRIPTION
Added a function that collapse topic names.

The topic tree is collapsed according to the following rule:

- If a node have 1 child that is not a leaf, then the child is collapsed into the father.

I decided to no collapse leaves (i.e. the last element of the topic name) for clarity purposes.



<img width="381" height="588" alt="image" src="https://github.com/user-attachments/assets/aa8aa955-d824-4cbe-a3c3-92d19fa39b7d" />
