### PR TITLE
Fix PointCloud2 viz crashing on NumPy 2.0

### DIFF
--- a/rosboard/compression.py
+++ b/rosboard/compression.py
@@ -3,6 +3,9 @@ import io
 import numpy as np
 from rosboard.cv_bridge import imgmsg_to_cv2
 
+# np.nbytes was removed in NumPy 2.0; np.dtype(...).itemsize is the replacement.
+_NUMPY_MAJOR_VERSION = int(np.__version__.split(".")[0])
+
 try:
     import simplejpeg
 except ImportError:
@@ -92,7 +95,10 @@ def decode_pcl2(cloud, field_names=None, skip_nans=False, uvs=[]):
             'invalid datatype %d specified for field %s' % (field.datatype, field.name)
         field_np_datatype = _PCL2_DATATYPES_NUMPY_MAP[field.datatype]
         np_struct.append((field.name, field_np_datatype))
-        total_used_bytes += np.nbytes[field_np_datatype]
+        if _NUMPY_MAJOR_VERSION >= 2:
+            total_used_bytes += np.dtype(field_np_datatype).itemsize
+        else:
+            total_used_bytes += np.nbytes[field_np_datatype]
 
     assert cloud.point_step >= total_used_bytes, \
         'error: total byte sizes of fields exceeds point_step'
@@ -266,13 +272,18 @@ def compress_point_cloud2(msg, output):
 
     try:
         points = decode_pcl2(msg, field_names = decode_fields, skip_nans = True)
-    except AssertionError as e:
+    except (AssertionError, ValueError) as e:
         output["_error"] = "PointCloud2 error: %s" % str(e)
-    
+        return
+
     # exclude non-finite points
     points = points[np.isfinite(points['x']) & np.isfinite(points['y'])]
     if "z" in field_names:
         points = points[np.isfinite(points['z'])]
+
+    if points.size == 0:
+        output["_warn"] = "Point cloud contains no finite points."
+        return
 
     if points.size > 65536:
         output["_warn"] = "Point cloud too large, randomly subsampling to 65536 points."


### PR DESCRIPTION
## Summary
- This fix and PR was AI-developed, but directly reviewed and tested on Numpy 2.x. Did not test on Numpy <2.x
- `decode_pcl2()` used `np.nbytes[dtype]`, a mapping that was removed in NumPy 2.0. With numpy>=2.0 installed, every `PointCloud2` message raises an uncaught `AttributeError` inside the ROS callback thread, which crashes the whole rosboard node (not just that one message). Replaced with `np.dtype(dtype).itemsize`.
- `compress_point_cloud2()` caught `AssertionError` from `decode_pcl2()` (e.g. malformed field layout) but didn't `return`, so it fell through to use the never-assigned `points` variable, raising `UnboundLocalError`. Added the missing `return`, widened the `except` to also catch `ValueError`, and added a guard for an all-NaN/Inf point cloud that would otherwise crash on `np.max()`/`np.min()` of a zero-size array.

Found while visualizing a `sensor_msgs/PointCloud2` topic from a robot simulator

## Test plan
- [x] Reproduced the crash against a live `PointCloud2` publisher (xyz float32 fields, no padding) with numpy 2.3.5 installed
- [x] Confirmed the node previously died on the first `/pc` message (`AttributeError: np.nbytes was removed in the NumPy 2.0 release`)
- [x] Applied the fix, restarted the node, confirmed point cloud renders correctly in the web UI with no crash
